### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certification program",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Closes #6

## Changes
- Added **GitHub Skills** activity to the activities list in `src/app.py`
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Max participants: 25

## Context
Students were unable to sign up for the GitHub Skills activity announced by the principal. This is time-sensitive as registrations close end of week.